### PR TITLE
Remove extra quote from tslint error

### DIFF
--- a/tslint-jsdoc-rules/ts/jsdocRequireRule.ts
+++ b/tslint-jsdoc-rules/ts/jsdocRequireRule.ts
@@ -52,7 +52,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public static FAILURE_STRING_FACTORY = (memberType: string, memberName: string) => {
       memberName = memberName == null ? "" : ` '${memberName}'`;
-      return `Missing JSDoc element for ${memberType}${memberName}'`;
+      return `Missing JSDoc element for ${memberType}${memberName}`;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {


### PR DESCRIPTION
This pull request is a minor adjust the output of `jsdoc-require` tslint rule, which currently contains an extra quote.

```
...: Missing JSDoc element for function declaration 'fooBar''
```

Changes to-

```
...: Missing JSDoc element for function declaration 'fooBar'
```